### PR TITLE
remove stateless semicolon

### DIFF
--- a/generators/app/templates/_statelesscomponent.js
+++ b/generators/app/templates/_statelesscomponent.js
@@ -10,7 +10,7 @@ function <%= name %> (props) {
       <%= name %> 
     </h2>
   );
-};
+}
 
 <%= name %>.propTypes = {
   name: PropTypes.string


### PR DESCRIPTION
eslint threw an error for unnecessary semicolon before I had touched the file. this makes the initial stateless file error free